### PR TITLE
ToCobra: use dummy command for parse errors

### DIFF
--- a/action.go
+++ b/action.go
@@ -72,7 +72,7 @@ func ActionSpec(path string) carapace.Action {
 			return carapace.ActionMessage(err.Error())
 		}
 
-		cmdCobra, err := cmd.ToCobra()
+		cmdCobra, err := cmd.ToCobraE()
 		if err != nil {
 			return carapace.ActionMessage(err.Error())
 		}

--- a/cmd/carapace-spec/cmd/root.go
+++ b/cmd/carapace-spec/cmd/root.go
@@ -57,11 +57,7 @@ var rootCmd = &cobra.Command{
 		if flag := cmd.Flag("scrape"); flag != nil && flag.Changed {
 			specCmd.Scrape()
 		} else {
-			specCmdCobra, err := specCmd.ToCobra()
-			if err != nil {
-				return err
-			}
-			bridgeCompletion(specCmdCobra, abs, args[1:]...)
+			bridgeCompletion(specCmd.ToCobra(), abs, args[1:]...)
 		}
 		return nil
 	},
@@ -108,11 +104,7 @@ func init() {
 				c.Args[0] = "_carapace"
 			}
 
-			specCmdCobra, err := specCmd.ToCobra()
-			if err != nil {
-				return carapace.ActionMessage(err.Error())
-			}
-			return carapace.ActionExecute(specCmdCobra).Invoke(c).ToA()
+			return carapace.ActionExecute(specCmd.ToCobra()).Invoke(c).ToA()
 		}),
 	)
 

--- a/spec_test.go
+++ b/spec_test.go
@@ -82,7 +82,7 @@ func execute(t *testing.T, spec string, args ...string) string {
 	if err := yaml.Unmarshal([]byte(spec), &c); err != nil {
 		t.Error(err.Error())
 	}
-	cmd, err := c.ToCobra()
+	cmd, err := c.ToCobraE()
 	if err != nil {
 		t.Error(err.Error())
 	}


### PR DESCRIPTION
this lets the spec be sourced and error are visible on completion invocation
