### PR TITLE
Support extended flag attributes

### DIFF
--- a/pkg/command/flag.go
+++ b/pkg/command/flag.go
@@ -11,6 +11,9 @@ type Flag struct {
 	Longhand    string
 	Shorthand   string
 	Description string
+	Default     string
+	OptDefault  string
+	Deprecated  string
 
 	NameAsShorthand bool
 	Repeatable      bool

--- a/pkg/command/flagset.go
+++ b/pkg/command/flagset.go
@@ -10,6 +10,9 @@ type FlagSet map[string]Flag
 
 type Extended struct {
 	Description string `yaml:"description,omitempty" json:"description,omitempty" jsonschema_description:"Description of the flag"`
+	Default     string `yaml:"default,omitempty" json:"default,omitempty" jsonschema_description:"Default value of the flag"`
+	OptDefault  string `yaml:"optdefault,omitempty" json:"optdefault,omitempty" jsonschema_description:"Default value when the optional flag is present without an argument"`
+	Deprecated  string `yaml:"deprecated,omitempty" json:"deprecated,omitempty" jsonschema_description:"Deprecation message of the flag"`
 	Nargs       int    `yaml:"nargs,omitempty" json:"nargs,omitempty" jsonschema_description:"Amount of arguments consumed"`
 }
 
@@ -18,9 +21,12 @@ func (fs FlagSet) MarshalYAML() (any, error) {
 
 	for _, f := range fs {
 		switch {
-		case f.Nargs != 0: // TODO other values causing extended version
+		case f.Default != "" || f.OptDefault != "" || f.Deprecated != "" || f.Nargs != 0:
 			m[f.format()] = Extended{
 				Description: f.Description,
+				Default:     f.Default,
+				OptDefault:  f.OptDefault,
+				Deprecated:  f.Deprecated,
 				Nargs:       f.Nargs,
 			}
 		default:
@@ -52,6 +58,9 @@ func (fs *FlagSet) UnmarshalYAML(value *yaml.Node) error {
 				return err
 			}
 			f.Description, _ = v["description"].(string)
+			f.Default, _ = v["default"].(string)
+			f.OptDefault, _ = v["optdefault"].(string)
+			f.Deprecated, _ = v["deprecated"].(string)
 			f.Nargs, _ = v["nargs"].(int)
 
 			flagSet[f.Name()] = *f // TODO ref?

--- a/pkg/command/flagset_test.go
+++ b/pkg/command/flagset_test.go
@@ -19,6 +19,9 @@ func TestFlagSet(t *testing.T) {
 			Longhand:    "complex",
 			Shorthand:   "c",
 			Description: "some complex flag",
+			Default:     "default value",
+			OptDefault:  "optional default value",
+			Deprecated:  "use --other instead",
 			Value:       true,
 			Nargs:       2,
 		},
@@ -27,6 +30,9 @@ func TestFlagSet(t *testing.T) {
 	expected := `--string*!: some string flag
 -c, --complex=:
     description: some complex flag
+    default: default value
+    optdefault: optional default value
+    deprecated: use --other instead
     nargs: 2
 `
 	m, err := yaml.Marshal(fs)


### PR DESCRIPTION
Refs #377

## Summary
- add flag fields for `default`, `optdefault`, and `deprecated`
- include those fields in the extended flag representation when marshalling
- parse them back from extended YAML flag entries
- extend the FlagSet round-trip test to cover the new attributes alongside `nargs`

## Validation
- `go test ./pkg/command ./...`
- `git diff --check`
