### PR TITLE
fix: set C_ARG* and C_VALUE environment variables in macro expressions

### DIFF
--- a/example/run.yaml
+++ b/example/run.yaml
@@ -12,7 +12,7 @@ commands:
   - name: script
     commands:
       - name: macro
-        run: "$(tail -n${C_FLAG_LINES:-1} $@) ||| $chdir($tempdir)"
+        run: "$(tail -n${C_FLAG_LINES:-1} ${C_ARG0}) ||| $chdir($tempdir)"
         flags:
           -n, --lines=: output the last NUM lines
         completion:

--- a/run.go
+++ b/run.go
@@ -77,6 +77,11 @@ func (r run) parseMacro() func(cmd *cobra.Command, args []string) error {
 		context := r.context(cmd, nil)
 		context.Args = args // force context.Args contain all args (ignore Value)
 
+		for index, arg := range args {
+			context.Setenv(fmt.Sprintf("C_ARG%v", index), arg)
+		}
+		context.Setenv("C_VALUE", context.Value)
+
 		splitted := strings.Split(string(r), " ||| ")
 
 		m, err := macro.MacroMap[Macro]{


### PR DESCRIPTION
Previously parseMacro() did not set the C_ARG* and C_VALUE environment
variables before executing macros, unlike parseScript() and parseAlias().
This prevented macros from accessing positional arguments via
${C_ARG0}, ${C_ARG1}, etc.

The fix adds the same environment variable setup that already existed
in the other run types.

Assisted-by: Crush:minimax-m2.7
