### PR TITLE
output JSON format in `_carapace macro` listing and fix description tag

### DIFF
--- a/macro.go
+++ b/macro.go
@@ -8,7 +8,7 @@ import (
 // TODO lots of overlapping `macro` terms. Macro[I|V|N] don't match the embedded generic `macro.Macro` well.
 type Macro struct {
 	Name        string                       `json:"name"`
-	Description string                       `json:"descriptions,omitempty"`
+	Description string                       `json:"description,omitempty"`
 	Example     string                       `json:"example,omitempty"`
 	Function    string                       `json:"function,omitempty"`
 	Args        string                       `json:"args,omitempty"` // TODO shouldn't be necessary

--- a/register.go
+++ b/register.go
@@ -1,7 +1,9 @@
 package spec
 
 import (
+	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -23,17 +25,52 @@ func Register(cmd *cobra.Command) {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch len(args) {
 			case 0:
+				exe := executable()
 				keys := make([]string, 0, len(macros))
 				for k := range macros {
 					keys = append(keys, k)
 				}
 				sort.Strings(keys)
 
+				type macroEntry struct {
+					Name        string `json:"name"`
+					Signature   string `json:"signature"`
+					Description string `json:"description"`
+					Version     string `json:"version"`
+					Function    string `json:"function"`
+				}
+
+				type macroList struct {
+					Version string       `json:"version"`
+					Macros  []macroEntry `json:"macros"`
+				}
+
+				depVersions := resolveDepVersions()
+
+				entries := make([]macroEntry, 0, len(keys))
 				for _, key := range keys {
 					if strings.HasPrefix(key, "_") {
-						fmt.Fprintln(cmd.OutOrStdout(), strings.TrimPrefix(key, "_."))
+						m := macros[key]
+						sig := m.Signature()
+						if sig == "" {
+							sig = "—"
+						}
+						pkgPath, _, _ := strings.Cut(m.Function, "#")
+						entries = append(entries, macroEntry{
+							Name:        exe + strings.TrimPrefix(key, "_"),
+							Signature:   sig,
+							Description: m.Description,
+							Version:     depVersions[pkgPath],
+							Function:    m.Function,
+						})
 					}
 				}
+
+				output, _ := json.MarshalIndent(macroList{
+					Version: specVersion(),
+					Macros:  entries,
+				}, "", "  ")
+				fmt.Fprintln(cmd.OutOrStdout(), string(output))
 			case 1:
 				m, ok := macros["_."+args[0]]
 				if !ok {
@@ -79,4 +116,25 @@ func Register(cmd *cobra.Command) {
 			return ActionMacro("$_." + c.Args[0]).Shift(1)
 		}),
 	)
+}
+
+func specVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == "github.com/carapace-sh/carapace-spec" {
+				return dep.Version
+			}
+		}
+	}
+	return "unknown"
+}
+
+func resolveDepVersions() map[string]string {
+	m := make(map[string]string)
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			m[dep.Path] = dep.Version
+		}
+	}
+	return m
 }


### PR DESCRIPTION
The `_carapace macro` command (no args) now outputs a JSON object with
`version` and `macros` fields instead of plain macro names. Each macro
entry includes name, signature, description, version (resolved from
debug.ReadBuildInfo using the Function field's package path), and
function. The `_.` prefix is replaced with the executable name to
match the cross-executable macro reference format. Also fixes the
JSON tag typo `descriptions` → `description` in the Macro struct.

Assisted-by: Crush:glm-5.1
