### PR TITLE
add AddMacroI and AddMacroV with auto-naming from function name

### DIFF
--- a/cmd/carapace-spec/cmd/root.go
+++ b/cmd/carapace-spec/cmd/root.go
@@ -82,7 +82,7 @@ func init() {
 		}),
 	)
 
-	spec.AddMacro("Spec", spec.MacroI(spec.ActionSpec))
+	spec.AddMacroI(spec.ActionSpec, "completes a spec")
 	spec.Register(rootCmd)
 }
 

--- a/docs/src/carapace-spec/macros/custom.md
+++ b/docs/src/carapace-spec/macros/custom.md
@@ -1,6 +1,7 @@
 # Custom
 
-Custom macros can be added with [`AddMacro`](https://pkg.go.dev/github.com/carapace-sh/carapace-spec#AddMacro).
+Custom macros can be added with [`AddMacro`](https://pkg.go.dev/github.com/carapace-sh/carapace-spec#AddMacro)
+or the auto-naming variants [`AddMacroI`](https://pkg.go.dev/github.com/carapace-sh/carapace-spec#AddMacroI) and [`AddMacroV`](https://pkg.go.dev/github.com/carapace-sh/carapace-spec#AddMacroV).
 
 ```go
 // `$_noarg` without argument
@@ -11,6 +12,10 @@ AddMacro("arg", MacroI(func(u User) carapace.Action { return carapace.ActionValu
 
 // `$_vararg([another, example])` with variable arguments (primitive or struct)
 AddMacro("vararg", MacroV(func(s ...string) carapace.Action { return carapace.ActionValues()}))
+
+// auto-naming variants (name inferred from function, "Action" prefix stripped)
+AddMacroI(func(User) carapace.Action { return carapace.ActionValues() }) // registers as "User"
+AddMacroV(func(string) carapace.Action { return carapace.ActionValues() }) // registers as "String"
 ```
 
 > Arguments are parsed as `yaml` so only struct keys deviating from the default need to be set.

--- a/macro.go
+++ b/macro.go
@@ -1,6 +1,10 @@
 package spec
 
 import (
+	"reflect"
+	"runtime"
+	"strings"
+
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace-spec/pkg/macro"
 )
@@ -33,10 +37,52 @@ func addCoreMacro(s string, m Macro) {
 	macros[s] = m
 }
 
-// AddMacro adds a custom macro
-func AddMacro(s string, m Macro) {
-	// TODO is the underscore prefix still a good idea?
+// AddMacro adds a custom macro with explicit name
+func AddMacro(s string, m Macro, opts ...string) {
+	if len(opts) > 0 {
+		m.Description = opts[0]
+	}
+	if len(opts) > 1 {
+		m.Example = strings.Join(opts[1:], "\n")
+	}
 	macros["_."+s] = m
+}
+
+// AddMacroI adds a custom macro inferring the name from the function.
+// Strips the ".../actions/" path prefix and "Action" function prefix.
+// First string arg is description, any further strings are joined with "\n" as example.
+func AddMacroI[T any](f func(t T) carapace.Action, opts ...string) {
+	AddMacro(macroName(f), MacroI(f), opts...)
+}
+
+// AddMacroV adds a custom macro inferring the name from the function.
+// Strips the ".../actions/" path prefix and "Action" function prefix.
+// First string arg is description, any further strings are joined with "\n" as example.
+func AddMacroV[T any](f func(t ...T) carapace.Action, opts ...string) {
+	AddMacro(macroName(f), MacroV(f), opts...)
+}
+
+// macroName extracts the function name and strips prefixes.
+// For carapace-bin: "github.com/carapace-sh/carapace-bin/pkg/actions/tools/git.ActionRefs" -> "tools.git.Refs"
+// For carapace-spec: "github.com/carapace-sh/carapace-spec.ActionSpec" -> "Spec"
+func macroName(f any) string {
+	name := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+
+	// strip everything up to and including the last "/actions/" package
+	// e.g. "github.com/carapace-sh/carapace-bin/pkg/actions/tools/git" -> "tools/git"
+	if idx := strings.LastIndex(name, "/actions/"); idx >= 0 {
+		name = name[idx+9:] // +9 to skip "/actions/"
+	} else if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+
+	// strip "Action" prefix from function name
+	name = strings.TrimPrefix(name, "Action")
+
+	// replace remaining slashes with dots for nested package paths
+	name = strings.ReplaceAll(name, "/", ".")
+
+	return name
 }
 
 func MacroN(f func() carapace.Action) Macro {


### PR DESCRIPTION
Infers macro name by stripping the ".../actions/" path prefix and
"Action" function prefix (e.g., ActionSpec -> "Spec").

First string arg is description, any further strings are joined with
"\n" as example.

Assisted-by: Crush:minimax-m2.7
