### PR TITLE
add noprefix modifier macro, analogous to nospace

### DIFF
--- a/action.go
+++ b/action.go
@@ -141,6 +141,7 @@ func (a action) Parse(cmd *cobra.Command) carapace.Action {
 					"$list",
 					"$multiparts",
 					"$nospace",
+					"$noprefix",
 					"$prefix",
 					"$retain",
 					"$shift",

--- a/core.go
+++ b/core.go
@@ -15,6 +15,7 @@ func init() {
 	addCoreMacro("list", MacroI(func(s string) carapace.Action { return carapace.ActionValues() }))
 	addCoreMacro("multiparts", MacroI(func(s string) carapace.Action { return carapace.ActionValues() }))
 	addCoreMacro("nospace", MacroI(func(s string) carapace.Action { return carapace.ActionValues() }))
+	addCoreMacro("noprefix", MacroI(func(s string) carapace.Action { return carapace.ActionValues() }))
 	addCoreMacro("uniquelist", MacroI(func(s string) carapace.Action { return carapace.ActionValues() }))
 
 	addCoreMacro("directories", MacroN(carapace.ActionDirectories))

--- a/docs/src/carapace-spec/macros/modifier.md
+++ b/docs/src/carapace-spec/macros/modifier.md
@@ -72,6 +72,14 @@ The following macros can be passed as well instead of a static directory:
 ["one", "two/", "three,", "$nospace(/,)"]
 ```
 
+## noprefix
+
+[`$noprefix(<characters>)`](https://carapace-sh.github.io/carapace/carapace/action/noPrefix.html) disables common prefix for given character(s).
+
+```yaml
+["--", "---", "one--", "one---", "$noprefix(-)"]
+```
+
 ## prefix
 
 [`$pefix(<prefix>)`](https://carapace-sh.github.io/carapace/carapace/action/prefix.html) adds a prefix to the inserted values.

--- a/example/modifier.yaml
+++ b/example/modifier.yaml
@@ -9,6 +9,7 @@ commands:
       --list=: "$list"
       --multiparts=: "$multiparts"
       --nospace=: "$nospace"
+      --noprefix=: "$noprefix"
       --prefix=: "$prefix"
       --retain=: "$retain"
       --shift=: "$shift"
@@ -28,6 +29,7 @@ commands:
         list: ["one", "two", "three", "$list(,)"]
         multiparts: ["one/two/three", "$multiparts([/])"]
         nospace: ["one", "two/", "three,", "$nospace(/,)"]
+        noprefix: ["--", "---", "one--", "one---", "$noprefix(-)"]
         prefix: ["$files", "$prefix(file://)"]
         retain: ["one", "two", "three", "$retain([two])"]
         shift: ["one", "two", "three", "$filterargs", "$shift(1)"]
@@ -49,6 +51,7 @@ commands:
       --list=: "$list"
       --multiparts=: "$multiparts"
       --nospace=: "$nospace"
+      --noprefix=: "$noprefix"
       --prefix=: "$prefix"
       --retain=: "$retain"
       --shift=: "$shift"
@@ -68,6 +71,7 @@ commands:
         list: ["$(printf '%s\\n' one two three) ||| $list(,)"]
         multiparts: ["one/two/three ||| $multiparts([/])"]
         nospace: ["$(printf '%s\\n' one two/ three,) ||| $nospace(/,)"]
+        noprefix: ["$(printf '%s\\n' '--' '---' one-- one---) ||| $noprefix(-)"]
         prefix: ["$files ||| $prefix(file://)"]
         retain: ["$(printf '%s\\n' one two three) ||| $retain([two])"]
         shift: ["$(printf '%s\\n' one two three) ||| $filterargs ||| $shift(1)"]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/carapace-sh/carapace-spec
 go 1.24
 
 require (
-	github.com/carapace-sh/carapace v1.11.7
+	github.com/carapace-sh/carapace v1.12.0
 	github.com/carapace-sh/carapace-shlex v1.1.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/carapace-sh/carapace v1.11.7 h1:zcxY4f/lA71UDk5MdJK4H6a6ZI1tlD4NAqgaVHaeAYU=
-github.com/carapace-sh/carapace v1.11.7/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
+github.com/carapace-sh/carapace v1.12.0 h1:Re5zlpn8A8hlF+SLye3oitNTVB7FagBxMJIoEv5Gllw=
+github.com/carapace-sh/carapace v1.12.0/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
 github.com/carapace-sh/carapace-shlex v1.1.1 h1:ccmNeetAYZOk4IcV36youFDsXusT9uCNW2Njkw+QS+Q=
 github.com/carapace-sh/carapace-shlex v1.1.1/go.mod h1:lJ4ZsdxytE0wHJ8Ta9S7Qq0XpjgjU0mdfCqiI2FHx7M=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/modifier.go
+++ b/modifier.go
@@ -28,6 +28,7 @@ func (m modifier) Parse(s string) carapace.Action {
 			"$list":       MacroI(m.Action.List),
 			"$multiparts": MacroV(m.Action.MultiParts),
 			"$nospace":    MacroI(func(s string) carapace.Action { return m.Action.NoSpace([]rune(s)...) }),
+			"$noprefix":   MacroI(func(s string) carapace.Action { return m.Action.NoPrefix([]rune(s)...) }),
 			"$prefix":     MacroI(m.Action.Prefix),
 			"$retain":     MacroV(m.Action.Retain),
 			"$shift":      MacroI(m.Action.Shift),

--- a/modifier_test.go
+++ b/modifier_test.go
@@ -60,6 +60,13 @@ func TestModifier(t *testing.T) {
 				).NoSpace('/', ',').
 					Usage("$nospace"))
 
+			s.Run(command, "--noprefix", "one").
+				Expect(carapace.ActionValues(
+					"one--",
+					"one---",
+				).NoPrefix('-').
+					Usage("$noprefix"))
+
 			s.Run(command, "--retain", "").
 				Expect(carapace.ActionValues(
 					"two",


### PR DESCRIPTION
$noprefix disables common prefix insertion for given characters,
matching the carapace Action.NoPrefix method.

Assisted-by: Crush:deepseek-v4-flash
